### PR TITLE
Generates DISTRIBUTIONS variable automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OTELCOL_BUILDER_VERSION ?= 0.91.0
 OTELCOL_BUILDER_DIR ?= ${HOME}/bin
 OTELCOL_BUILDER ?= ${OTELCOL_BUILDER_DIR}/ocb
 
-DISTRIBUTIONS ?= "loadbalancing,sidecar,tracing"
+DISTRIBUTIONS ?= $(shell echo $(notdir $(wildcard ./distributions/*)) | tr " " ",") # outputs comma separated directories names
 
 ci: check build
 check: test

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ At every new version of the Collector, distributions are updated and published.
 To add a new distribution to this repository:
 
 1) create a directory under `distributions` and place the `manifest.yaml` there
-2) change the `Makefile`'s `DISTRIBUTIONS` var to include the new distribution
-3) add `./github/workflows/ci-<distribution>.yaml` and `./github/workflows/release-<distribution>.yaml` files based on one of the existing distributions
+2) add `./github/workflows/ci-<distribution>.yaml` and `./github/workflows/release-<distribution>.yaml` files based on one of the existing distributions
 
 You can test your new distribution with:
 


### PR DESCRIPTION
## Contributions
This Pull Request aims to reduce the number of steps for 'Adding a new distribution'.
With these changes, the step number 2 is no longer needed. 

Basically, when new folders gets added under `distributions` directory, the Makefile will
be able to automatically read all directories in the proper expected format: comma separated.

## How to test

1. Create a new directory under distributions folder: `mkdir distributions/test-distribution`
2. Now run Makefile with `-n` option to print what is supposed to run but without actually running it:
```bash
$> make -n                                                                                                            
{ \
        if ! command -v 'go' >/dev/null 2>/dev/null; then \
                echo >&2 'go command not found. Please install golang. https://go.dev/doc/install'; \
                exit 1; \
        fi \
}
{ \
[ ! -x '/Users/pantuza/bin/ocb' ] || exit 0; \
set -e ;\
os=$(uname | tr A-Z a-z) ;\
machine=$(uname -m) ;\
[ "${machine}" != x86 ] || machine=386 ;\
[ "${machine}" != x86_64 ] || machine=amd64 ;\
echo "Installing ocb (${os}/${machine}) at /Users/pantuza/bin";\
mkdir -p /Users/pantuza/bin ;\
curl -sLo /Users/pantuza/bin/ocb "https://github.com/open-telemetry/opentelemetry-collector/releases/download/cmd%2Fbuilder%2Fv0.91.0/ocb_0.91.0_${os}_${machine}" ;\
chmod +x /Users/pantuza/bin/ocb ;\
}
./scripts/build.sh -d "loadbalancing,sidecar,test-distribution,tracing " -b /Users/pantuza/bin/ocb -g go
./test/test-all.sh -d "loadbalancing,sidecar,test-distribution,tracing "
```

As you can see (last line), Makefile is properly creating the list of distributions as expected: `loadbalancing,sidecar,test-distribution,tracing`

## Considerations
Please, feel free to simply close this PR in case it does not makes sense.
 