### PR TITLE
ci(Renovate): update opentelemetry builder dependencies automatically

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,35 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "ocb": {
+    "fileMatch": [
+      "^distributions\\/.*manifest\\.ya?ml$"
+    ]
+  },
+  "packageRules": [
+    {
+      "matchSourceUrls": [
+        "https://github.com/open-telemetry/opentelemetry-collector",
+        "https://github.com/open-telemetry/opentelemetry-collector-contrib"
+      ],
+      "groupName": "otel-collector upstream dependencies"
+    }
+  ],
+  "customManagers": [
+    {
+      "description": "version field and OTELCOL_BUILDER_VERSION should follow upstream",
+      "fileMatch": [
+        "^distributions\\/.*manifest\\.ya?ml$",
+        "^Makefile$"
+      ],
+      "matchStrings": [
+        "\\sversion:\\s+(?<currentValue>\\S+)",
+        "OTELCOL_BUILDER_VERSION\\s*\\?=\\s*(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "open-telemetry/opentelemetry-collector",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
   ]
 }


### PR DESCRIPTION
Closes #20

Adds the necessary configs to upgrade all fields, tough to get https://github.com/secustor/otelcol-distributions/pull/2 you should wait for https://github.com/renovatebot/renovate/pull/26862 as it fixes some extractions